### PR TITLE
defaults to using depth of 1 like folders, uses transient tile and has much nicer more readable params

### DIFF
--- a/plone/app/contentlistingtile/configure.zcml
+++ b/plone/app/contentlistingtile/configure.zcml
@@ -31,10 +31,10 @@
       description="A tile which displays the content listing of this item"
       icon="++resource++plone.app.contentlistingtile.png"
       permission="zope2.View"
-      add_permission="plone.app.tiles.AddTile"
+      add_permission="plone.ModifyDecoLayout"
       class=".tile.ContentListingTile"
       schema=".tile.IContentListingTile"
-      for="Products.CMFCore.interfaces.IFolderish"
+      for="*"
       />
 
   <browser:page

--- a/plone/app/contentlistingtile/configure.zcml
+++ b/plone/app/contentlistingtile/configure.zcml
@@ -37,6 +37,17 @@
       for="*"
       />
 
+    <view
+        for=".tile.ContentListingTile"
+        factory=".tile.ListingTileAbsoluteURL"
+        type="zope.publisher.interfaces.http.IHTTPRequest"
+        permission="zope.Public"
+        provides="zope.traversing.browser.interfaces.IAbsoluteURL"
+        />
+
+    <adapter factory=".tile.ListingTileDataManager" />
+
+
   <browser:page
       name="tabular_view"
       for="*"

--- a/plone/app/contentlistingtile/tile.py
+++ b/plone/app/contentlistingtile/tile.py
@@ -36,7 +36,7 @@ class IContentListingTile(directivesform.Schema):
                         required=False,
                         default=[{'i':'path',
                                   'o':'plone.app.querystring.operation.string.relativePath',
-                                  'v':'.'}])
+                                  'v':'.::1'}])
 
 
 
@@ -138,7 +138,6 @@ def query_encode(data, short_operators):
         i = criteria['i']
         o = criteria['o']
         v = criteria['v']
-        #TODO: should use default
         short_op = short_operators[i][1][o]
         if short_op:
             i = "%s:%s" % (i,short_op)

--- a/plone/app/contentlistingtile/tile.py
+++ b/plone/app/contentlistingtile/tile.py
@@ -141,6 +141,9 @@ def query_encode(data, short_operators):
         short_op = short_operators[i][1][o]
         if short_op:
             i = "%s:%s" % (i,short_op)
+        # HACK can we assume ',' as a delimter for all operators?
+        if isinstance(v, list):
+            v = ', '.join(v)
         new_data[i] = v
     return urllib.urlencode(new_data)
 
@@ -158,6 +161,8 @@ def query_decode(data, short_operators):
             o = short2long.get(o,o)
         else:
             o = short2long.get('')
+        if ',' in v:
+            v = [s.strip() for s in v.split(',')]
         criteria = dict(i=i,o=o,v=v)
         query.append(criteria)
     data['query'] = query

--- a/plone/app/contentlistingtile/tile.py
+++ b/plone/app/contentlistingtile/tile.py
@@ -151,6 +151,8 @@ def query_decode(data, short_operators):
     for i,v in data.items():
         if i in ['view_template', 'query']:
             continue
+        if i not in short_operators:
+            continue
         short2long = short_operators[i][0]
         if ':' in i:
             i, o = i.split(':')

--- a/plone/app/contentlistingtile/tile.py
+++ b/plone/app/contentlistingtile/tile.py
@@ -23,7 +23,10 @@ class IContentListingTile(directivesform.Schema):
                                       u'you want to list by choosing what to '
                                       u'match on. The list of results will '
                                       u'be dynamically updated'),
-                        required=False)
+                        required=False,
+                        default=[{'i':'path',
+                                  'o':'plone.app.querystring.operation.string.relativePath',
+                                  'v':'.'}])
 
     view_template = schema.Choice(title=_(u"Display mode"),
                                   source=_(u"Available Listing Views"),


### PR DESCRIPTION
in part the more readable params was for shortcode like params for use collective.tinymcetiles but its still a nice thing to have in mosaic if anyone looks at the code. FYI tinymce tiles used a shortcode syntax like 
`[plone.app.contentlistingtile view_template="listing_view" path=".::1"]` enabling any transient tile to be easily inserted either via UI, by hand or by cut and paste.
